### PR TITLE
Don't harcode the docroot

### DIFF
--- a/nubis/puppet/static.pp
+++ b/nubis/puppet/static.pp
@@ -33,7 +33,7 @@ define nubis::static (
     redirectmatch_regexp => $redirectmatch_regexp,
     redirectmatch_dest   => $redirectmatch_dest,
 
-    docroot              => "/data/haul/${title}",
+    docroot              => "/data/tpe-haul/${title}",
 
     directoryindex       => join(concat($indexes, $default_indexes), ' '),
 

--- a/nubis/puppet/static.pp
+++ b/nubis/puppet/static.pp
@@ -33,7 +33,7 @@ define nubis::static (
     redirectmatch_regexp => $redirectmatch_regexp,
     redirectmatch_dest   => $redirectmatch_dest,
 
-    docroot              => "/data/tpe-haul/${title}",
+    docroot              => "/data/${project_name}/${title}",
 
     directoryindex       => join(concat($indexes, $default_indexes), ' '),
 

--- a/nubis/terraform/sites.tf
+++ b/nubis/terraform/sites.tf
@@ -7,6 +7,7 @@ module "tpe" {
   service_name = "${var.service_name}"
   role         = "${module.worker.role}"
 
-  site_name  = "tpe"
-  site_index = "index.htm"
+  site_name     = "tpe"
+  site_index    = "index.htm"
+  site_git_repo = "https://github.com/limed/tpe-haul"
 }

--- a/nubis/terraform/sites/main.tf
+++ b/nubis/terraform/sites/main.tf
@@ -39,4 +39,10 @@ resource "consul_keys" "config" {
     value  = "${var.site_git_branches}"
     delete = true
   }
+
+  key {
+    path    = "${module.consul.config_prefix}/sites/${var.site_name}/git_repo"
+    value   = "${var.site_git_repo}"
+    delete  = true
+  }
 }

--- a/nubis/terraform/sites/variables.tf
+++ b/nubis/terraform/sites/variables.tf
@@ -33,3 +33,7 @@ variable "site_build_frequency" {
 variable "site_git_branches" {
   default = "master"
 }
+
+variable "site_git_repo" {
+  default = "https://github.com/mozilla-it/haul.git"
+}


### PR DESCRIPTION
We shouldn't harcode the docroot, instead we should use the ${project_name}